### PR TITLE
License metadata mismatch: repository LICENSE says Apache-2.0 but pub…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,8 @@
 
     <licenses>
         <license>
-            <name>MIT</name>
-            <url>http://opensource.org/licenses/MIT</url>
+            <name>Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
     </licenses>
 


### PR DESCRIPTION
…lished POM declares MIT #136

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project license from MIT to Apache License, Version 2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->